### PR TITLE
Update Package.swift - removed unsafe build flags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
             dependencies: ["GemiusSDKtvOSFramework"],
             linkerSettings: [
                 .linkedFramework("AdSupport"),
-                .linkedFramework("SystemConfiguration"),
-                .unsafeFlags(["-ObjC"])
+                .linkedFramework("SystemConfiguration")
             ]
         ),
         .binaryTarget(


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request addresses an important update to the Swift Package Manager (SPM) package configuration:

1. **Removal of Unsafe Flags**: Unsafe flags have been removed from the package configuration. These flags are not permitted in published SPM packages, ensuring compliance with SPM guidelines and enhancing the safety and stability of the package.

2. **Proposal for Adherence to Semantic Versioning**: We propose updating the package to follow the required semantic versioning guidelines. Instead of referencing specific commits or branches for versioning, we suggest aligning the versioning strategy with the semantic versioning requirements outlined in the [Swift Package Manager Documentation](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency-requirement). Implementing this change will facilitate stable version dependency management and compatibility for users of the package. Adding a version can be easily achieved by simply **adding a tag**.

#### Changes Made
- Removed all instances of unsafe flags from the package configuration.

#### Proposed Changes
- Update versioning to comply with semantic versioning standards (not yet implemented).